### PR TITLE
Makes sure new functions in native types are not enumerable

### DIFF
--- a/modules/functions.js
+++ b/modules/functions.js
@@ -139,15 +139,19 @@ module.exports = (client) => {
   
   // <String>.toPropercase() returns a proper-cased string such as: 
   // "Mary had a little lamb".toProperCase() returns "Mary Had A Little Lamb"
-  String.prototype.toProperCase = function() {
-    return this.replace(/([^\W_]+[^\s-]*) */g, function(txt) {return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-  };    
-  
+  Object.defineProperty(String.prototype, "toProperCase", {
+    value: function() {
+      return this.replace(/([^\W_]+[^\s-]*) */g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+    }
+  });
+
   // <Array>.random() returns a single random element from an array
   // [1, 2, 3, 4, 5].random() can return 1, 2, 3, 4 or 5.
-  Array.prototype.random = function() {
-    return this[Math.floor(Math.random() * this.length)]
-  };
+  Object.defineProperty(Array.prototype, "random", {
+    value: function() {
+      return this[Math.floor(Math.random() * this.length)];
+    }
+  });
 
   // `await client.wait(1000);` to "pause" for 1 second.
   client.wait = require("util").promisify(setTimeout);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
Uses [Object.defineProperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) to add the custom functions as non-enumerable properties. This is better practice, but particularly useful on the `Array.prototype`, as without it, loops like this are useless, as they iterate over the function well as the intended elements
```js
for (i in ['a', 'b']) {
    // do something
}
```

**Semantic versioning classification:**  
- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
