### PR TITLE
More response

### DIFF
--- a/commands/eval.js
+++ b/commands/eval.js
@@ -11,9 +11,25 @@ exports.run = async (client, message, args, level) => { // eslint-disable-line n
   try {
     const evaled = eval(code);
     const clean = await client.clean(client, evaled);
-    message.channel.send(`\`\`\`js\n${clean}\n\`\`\``);
+    if (clean.length > 1990) {
+      if (this.logLongOutput) {
+        console.log(evaled);
+        return client.successEmbed(message.channel, "Execution complete and output to console");
+      } else {
+        return message.channel.send("Execution complete, output has been trimmed```\n" + clean.substring(0, 1949) + "```");
+      }
+    }
+    message.channel.send("```js\n" + clean + "```");
   } catch (err) {
-    message.channel.send(`\`ERROR\` \`\`\`xl\n${await client.clean(client, err)}\n\`\`\``);
+    if (err.length > 1990) {
+      if (this.logLongOutput) {
+        console.log(err);
+        return client.errorEmbed(message.channel, "Execution failed and stacktrace logged");
+      } else {
+        return client.errorEmbed(message.channel, "Execution failed, stacktrace has been trimmed```\n" + err.substring(0, 1947) + "```");
+      }
+    }
+    client.errorEmbed(message.channel, "```xl\n" + await client.clean(client, err) + "```");
   }
 };
 
@@ -21,7 +37,8 @@ exports.conf = {
   enabled: true,
   guildOnly: false,
   aliases: [],
-  permLevel: "Bot Owner"
+  permLevel: "Bot Owner",
+  logLongOutput: false
 };
 
 exports.help = {

--- a/config.js.example
+++ b/config.js.example
@@ -98,7 +98,11 @@ const config = {
       // Another simple check, compares the message author id to the one stored in the config file.
       check: (message) => message.client.config.ownerID === message.author.id
     }
-  ]
+  ],
+  emojiConvertReference: {
+    "?": ":question_mark:",
+    "!": ":exclamation:"
+  }
 };
 
 module.exports = config;

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -45,61 +45,22 @@ module.exports = (client) => {
     return returns;
   };
   /**
-   * Converts a given string or number to blocktext
+   * Converts a string or number to blocktext. Input must only be one character
+   * 
+   * Uses the client.config.emojiConvertReference (Set in config.js) to convert
+   * any characters that exist in that file, and has a fallback for
+   * alphabetical and numerical characters
    * @constructor
-   * @param {String} string The string to be converted
+   * @param {String|Number} string The value to be converted
    * @returns {String} A blocktext version of the passed string
    */
-  // TODO: Make a better way of getting the emojiConvert variable. In config maybe?
-  client.toBlocktext = (string, emojiConvert = {
-    "0": ":zero:",
-    "1": ":one:",
-    "2": ":two:",
-    "3": ":three:",
-    "4": ":four:",
-    "5": ":five:",
-    "6": ":six:",
-    "7": ":seven:",
-    "8": ":eight:",
-    "9": ":nine:",
-    "A": ":regional_indicator_a:",
-    "B": ":regional_indicator_b:",
-    "C": ":regional_indicator_c:",
-    "D": ":regional_indicator_d:",
-    "E": ":regional_indicator_e:",
-    "F": ":regional_indicator_f:",
-    "G": ":regional_indicator_g:",
-    "H": ":regional_indicator_h:",
-    "I": ":regional_indicator_i:",
-    "J": ":regional_indicator_j:",
-    "K": ":regional_indicator_k:",
-    "L": ":regional_indicator_l:",
-    "M": ":regional_indicator_m:",
-    "N": ":regional_indicator_n:",
-    "O": ":regional_indicator_o:",
-    "P": ":regional_indicator_p:",
-    "Q": ":regional_indicator_q:",
-    "R": ":regional_indicator_r:",
-    "S": ":regional_indicator_s:",
-    "T": ":regional_indicator_t:",
-    "U": ":regional_indicator_u:",
-    "V": ":regional_indicator_v:",
-    "W": ":regional_indicator_w:",
-    "X": ":regional_indicator_x:",
-    "Y": ":regional_indicator_y:",
-    "Z": ":regional_indicator_z:",
-    " ": "     ",
-    ".": ":large_blue_circle:",
-    "!": ":exclamation:",
-    "?": ":question:"
-  }) => {
-    if (typeof string === "number") string = string.toString();
-    string = string.toUpperCase().split("");
-    let blocktext = "";
-    for (let i = 0; i < string.length; i++) {
-      blocktext = blocktext + emojiConvert[string[i]] ? emojiConvert[string[i]] : string[i];
-    }
-    return blocktext;
+  client.toEmojiString = (input) => {
+    if (input.toString()) input = input.toString();
+    if (client.config.emojiConvertReference && client.config.emojiConvertReference[input]) return client.config.emojiConvertReference[input];
+    if (input.length > 1) return new Error("Input too long");
+    if (parseInt(input)) return [":zero:",":one:", ":two:", ":three:", ":four:", ":five:", ":six:", ":seven:", ":eight:", ":nine:"][input];
+    if (/[a-z|A-Z]/.test(input)) return input.replace(/[a-z|A-Z]/, i => `:regional_indicator_${i.toLowerCase()}:`);
+    return input;
   };
   /*
   SINGLE-LINE AWAITMESSAGE
@@ -193,7 +154,7 @@ module.exports = (client) => {
       if (options.length > 9) return reject(new Error("Too many options"));
       channel.send(description && ["Embed", "String"].includes(description.constructor.name) ? description : new Discord.RichEmbed({
         "title": "Multiple Choice",
-        "description": "React to this message to choose.\n\n" + options.map(i => client.toBlocktext(options.indexOf(i) + 1) + " " + i).join("\n")
+        "description": "React to this message to choose.\n\n" + options.map(i => client.toEmojiString(options.indexOf(i) + 1) + " " + i).join("\n")
       })).then(async (prompt) => {
         prompt.reactives = [];
         prompt.createReactionCollector((reaction, user) => user != client.user && reaction.message.reactives.includes(reaction) && (subject ? [subject, subject.id].includes(user.id) : true), {

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -69,7 +69,19 @@ module.exports = (client) => {
       return false;
     }
   };
-
+  /**
+   * Gets user's nickname given a context, if a nickname is not set, the username wil be returned
+   * @constructor
+   * @param {Guild|Message|TextChannel|VoiceChannel|MessageReaction} context The context to check the nickname in
+   * @param {User} [user=client.user] The user who's name to check
+   * @returns {String} The nickname of the user in the given context
+   */
+  client.getNickname = (context, user = client.user) => {
+    if (context.constructor.name == "MessageReaction") context = context.message;
+    if (context.constructor.name == "Message" || "TextChannel" || "VoiceChannel") context = context.guild;
+    context = context.members.get(user.id).nickname;
+    return context ? context : user.username;
+  };
 
   /*
   MESSAGE CLEAN FUNCTION
@@ -118,7 +130,7 @@ module.exports = (client) => {
       command = client.commands.get(client.aliases.get(commandName));
     }
     if (!command) return `The command \`${commandName}\` doesn"t seem to exist, nor is it an alias. Try again!`;
-  
+
     if (command.shutdown) {
       await command.shutdown(client);
     }
@@ -134,18 +146,18 @@ module.exports = (client) => {
   };
 
   /* MISCELANEOUS NON-CRITICAL FUNCTIONS */
-  
+
   // EXTENDING NATIVE TYPES IS BAD PRACTICE. Why? Because if JavaScript adds this
   // later, this conflicts with native code. Also, if some other lib you use does
   // this, a conflict also occurs. KNOWING THIS however, the following 2 methods
   // are, we feel, very useful in code. 
-  
+
   // <String>.toPropercase() returns a proper-cased string such as: 
   // "Mary had a little lamb".toProperCase() returns "Mary Had A Little Lamb"
   String.prototype.toProperCase = function() {
     return this.replace(/([^\W_]+[^\s-]*) */g, function(txt) {return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
   };    
-  
+
   // <Array>.random() returns a single random element from an array
   // [1, 2, 3, 4, 5].random() can return 1, 2, 3, 4 or 5.
   Array.prototype.random = function() {

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -51,7 +51,7 @@ module.exports = (client) => {
    * any characters that exist in that file, and has a fallback for
    * alphabetical and numerical characters
    * @constructor
-   * @param {String|Number} string The value to be converted
+   * @param {String|Number} input The value to be converted
    * @returns {String} A blocktext version of the passed string
    */
   client.toEmojiString = (input) => {

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -1,3 +1,4 @@
+const Discord = require("discord.js");
 module.exports = (client) => {
 
   /*
@@ -69,6 +70,40 @@ module.exports = (client) => {
       return false;
     }
   };
+  /**
+   * Sends an embed with parameters to the given channel.
+   * @constructor
+   * @param {Channel} channel The channel which the Embed should be sent to
+   * @param {String} title The title for the Embed
+   * @param {String} description The description for the Embed
+   * @param {Color} color The color for the Embed
+   * @returns {Promise} Resolves to the sent message
+   */
+  client.coloredEmbed = (channel, title, description, color) => {
+    return new Promise((resolve, reject) => {
+      channel.send(new Discord.RichEmbed({
+        "title": title,
+        "description": description,
+        "color": color
+      })).then(resolve).catch(reject);
+    });
+  };
+  /**
+   * Sends an Embed to the given Channel describing a success - Has title 'Success' and color 0x43B581
+   * @constructor
+   * @param {Channel} channel The channel which the Embed should be sent to
+   * @param {String} description The description for the Embed
+   * @returns {Promise} Resolves to the sent message
+   */
+  client.successEmbed = (channel, description) => client.coloredEmbed(channel, "Success", description, 0x43B581);
+  /**
+   * Sends an Embed to the given Channel describing an error - Has title 'Error' and color 0xF04747
+   * @constructor
+   * @param {Channel} channel The channel which the Embed should be sent to
+   * @param {String} description The description for the Embed
+   * @returns {Promise} Resolves to the sent message
+   */
+  client.errorEmbed = (channel, description) => client.coloredEmbed(channel, "Error", description, 0xF04747);
   /**
    * Gets user's nickname given a context, if a nickname is not set, the username wil be returned
    * @constructor

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -50,6 +50,9 @@ module.exports = (client) => {
   A simple way to grab a single reply, from the user that initiated
   the command. Useful to get "precisions" on certain things...
 
+  Though useful, this is bad practice, as it holds the async thread
+  in memory indefinitely. Use callbacks where possible.
+
   USAGE
 
   const response = await client.awaitReply(msg, "Favourite Color?");
@@ -146,7 +149,7 @@ module.exports = (client) => {
   // <Array>.random() returns a single random element from an array
   // [1, 2, 3, 4, 5].random() can return 1, 2, 3, 4 or 5.
   Array.prototype.random = function() {
-    return this[Math.floor(Math.random() * this.length)]
+    return this[Math.floor(Math.random() * this.length)];
   };
 
   // `await client.wait(1000);` to "pause" for 1 second.

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -44,7 +44,63 @@ module.exports = (client) => {
     }
     return returns;
   };
-
+  /**
+   * Converts a given string or number to blocktext
+   * @constructor
+   * @param {String} string The string to be converted
+   * @returns {String} A blocktext version of the passed string
+   */
+  // TODO: Make a better way of getting the emojiConvert variable. In config maybe?
+  client.toBlocktext = (string, emojiConvert = {
+    "0": ":zero:",
+    "1": ":one:",
+    "2": ":two:",
+    "3": ":three:",
+    "4": ":four:",
+    "5": ":five:",
+    "6": ":six:",
+    "7": ":seven:",
+    "8": ":eight:",
+    "9": ":nine:",
+    "A": ":regional_indicator_a:",
+    "B": ":regional_indicator_b:",
+    "C": ":regional_indicator_c:",
+    "D": ":regional_indicator_d:",
+    "E": ":regional_indicator_e:",
+    "F": ":regional_indicator_f:",
+    "G": ":regional_indicator_g:",
+    "H": ":regional_indicator_h:",
+    "I": ":regional_indicator_i:",
+    "J": ":regional_indicator_j:",
+    "K": ":regional_indicator_k:",
+    "L": ":regional_indicator_l:",
+    "M": ":regional_indicator_m:",
+    "N": ":regional_indicator_n:",
+    "O": ":regional_indicator_o:",
+    "P": ":regional_indicator_p:",
+    "Q": ":regional_indicator_q:",
+    "R": ":regional_indicator_r:",
+    "S": ":regional_indicator_s:",
+    "T": ":regional_indicator_t:",
+    "U": ":regional_indicator_u:",
+    "V": ":regional_indicator_v:",
+    "W": ":regional_indicator_w:",
+    "X": ":regional_indicator_x:",
+    "Y": ":regional_indicator_y:",
+    "Z": ":regional_indicator_z:",
+    " ": "     ",
+    ".": ":large_blue_circle:",
+    "!": ":exclamation:",
+    "?": ":question:"
+  }) => {
+    if (typeof string === "number") string = string.toString();
+    string = string.toUpperCase().split("");
+    let blocktext = "";
+    for (let i = 0; i < string.length; i++) {
+      blocktext = blocktext + emojiConvert[string[i]] ? emojiConvert[string[i]] : string[i];
+    }
+    return blocktext;
+  };
   /*
   SINGLE-LINE AWAITMESSAGE
 
@@ -64,7 +120,11 @@ module.exports = (client) => {
     const filter = m => m.author.id === msg.author.id;
     await msg.channel.send(question);
     try {
-      const collected = await msg.channel.awaitMessages(filter, { max: 1, time: limit, errors: ["time"] });
+      const collected = await msg.channel.awaitMessages(filter, {
+        max: 1,
+        time: limit,
+        errors: ["time"]
+      });
       return collected.first().content;
     } catch (e) {
       return false;
@@ -105,7 +165,7 @@ module.exports = (client) => {
    */
   client.errorEmbed = (channel, description) => client.coloredEmbed(channel, "Error", description, 0xF04747);
   /**
-   * Gets user's nickname given a context, if a nickname is not set, the username wil be returned
+   * Gets user's nickname given a context, if a nickname is not set, the username will be returned
    * @constructor
    * @param {Guild|Message|TextChannel|VoiceChannel|MessageReaction} context The context to check the nickname in
    * @param {User} [user=client.user] The user who's name to check
@@ -131,16 +191,16 @@ module.exports = (client) => {
       if (options.length == 0) return reject(new Error("No options"));
       if (options.length == 1) return resolve(options[0]);
       if (options.length > 9) return reject(new Error("Too many options"));
-      channel.send(description.constructor.name == "Embed" || "String" ? description : new Discord.RichEmbed({
+      channel.send(description && ["Embed", "String"].includes(description.constructor.name) ? description : new Discord.RichEmbed({
         "title": "Multiple Choice",
         "description": "React to this message to choose.\n\n" + options.map(i => client.toBlocktext(options.indexOf(i) + 1) + " " + i).join("\n")
       })).then(async (prompt) => {
         prompt.reactives = [];
-        prompt.createReactionCollector((reaction, user) => reaction.message && reaction.message.reactives.includes(reaction) && subject ? user.id == subject || subject.id : true, {
+        prompt.createReactionCollector((reaction, user) => user != client.user && reaction.message.reactives.includes(reaction) && (subject ? [subject, subject.id].includes(user.id) : true), {
           "maxEmojis": 1
         }).on("collect", r => {
           r.message.delete();
-          if (r.emoji.name == "❌") return reject(2);
+          if (r.emoji.name == "❌") return reject(new Error("User Rejected"));
           resolve(options[parseInt(r.emoji.identifier.charAt(0)) - 1]);
         });
         await prompt.react("❌").then(r => {
@@ -167,7 +227,9 @@ module.exports = (client) => {
     if (text && text.constructor.name == "Promise")
       text = await text;
     if (typeof evaled !== "string")
-      text = require("util").inspect(text, {depth: 1});
+      text = require("util").inspect(text, {
+        depth: 1
+      });
 
     text = text
       .replace(/`/g, "`" + String.fromCharCode(8203))
@@ -227,8 +289,10 @@ module.exports = (client) => {
   // <String>.toPropercase() returns a proper-cased string such as: 
   // "Mary had a little lamb".toProperCase() returns "Mary Had A Little Lamb"
   String.prototype.toProperCase = function() {
-    return this.replace(/([^\W_]+[^\s-]*) */g, function(txt) {return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-  };    
+    return this.replace(/([^\W_]+[^\s-]*) */g, function(txt) {
+      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    });
+  };
 
   // <Array>.random() returns a single random element from an array
   // [1, 2, 3, 4, 5].random() can return 1, 2, 3, 4 or 5.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
Adds some new useful commands to the `client` object.

I also rewrote the `eval` command to make use of the new functions and avoid the `String value is too long` DiscordAPI error

#### client.coloredEmbed(channel, title, description, color) 

Sends an embed with parameters to the given channel.




##### Parameters

| Name | Type | Description |  |
| ---- | ---- | ----------- | -------- |
| channel | `Channel`  | The channel which the Embed should be sent to | &nbsp; |
| title | `String`  | The title for the Embed | &nbsp; |
| description | `String`  | The description for the Embed | &nbsp; |
| color | `Color`  | The color for the Embed | &nbsp; |




##### Returns


- `Promise`  Resolves to the sent message


##### Example
`events/message.js` :
```js
9 |  client.coloredEmbed(message.channel, "Hello", "world", 0x5511AA);
```
![image](https://user-images.githubusercontent.com/25057690/45642366-e0e5cd80-baaf-11e8-90da-f581eb9a699b.png)


#### client.successEmbed(channel, description) 

Sends an Embed to the given Channel describing a success - Has title 'Success' and color 0x43B581




##### Parameters

| Name | Type | Description |  |
| ---- | ---- | ----------- | -------- |
| channel | `Channel`  | The channel which the Embed should be sent to | &nbsp; |
| description | `String`  | The description for the Embed | &nbsp; |




##### Returns


- `Promise`  Resolves to the sent message


##### Example
`events/message.js`:
```js
9 |  client.successEmbed(message.channel, "It went good!");
```
![image](https://user-images.githubusercontent.com/25057690/45642579-7d0fd480-bab0-11e8-8119-b100a6f1726f.png)


#### client.errorEmbed(channel, description) 

Sends an Embed to the given Channel describing an error - Has title 'Error' and color 0xF04747




##### Parameters

| Name | Type | Description |  |
| ---- | ---- | ----------- | -------- |
| channel | `Channel`  | The channel which the Embed should be sent to | &nbsp; |
| description | `String`  | The description for the Embed | &nbsp; |




##### Returns


- `Promise`  Resolves to the sent message


##### Example
`events/message.js`:
```js
9 |  client.errorEmbed(message.channel, "It went bad :(");
```
![image](https://user-images.githubusercontent.com/25057690/45642707-f0b1e180-bab0-11e8-8d80-84e8b7d78786.png)


#### client.toEmojiString(string) 

Converts a string or number to blocktext. Input must only be one character

Uses the client.config.emojiConvertReference (Set in config.js) to convert
any characters that exist in that file, and has a fallback for
alphabetical and numerical characters




##### Parameters

| Name | Type | Description |  |
| ---- | ---- | ----------- | -------- |
| input | `String` `Number`  | The value to be converted | &nbsp; |




##### Returns


- `String`  A blocktext version of the passed string

##### Example
```js
client.toEmojiString(1)
":one:"
client.toEmojiString('1')
":one:"
client.toEmojiString('a')
":regional_indicator_a:"
client.toEmojiString('b')
":regional_indicator_b:"
client.toEmojiString('?')
":question_mark:"
client.toEmojiString('long string')
Error: Input too long
```

#### client.getNickname(context) 

Gets user's nickname given a context, if a nickname is not set, the username will be returned




##### Parameters

| Name | Type | Description |  |
| ---- | ---- | ----------- | -------- |
| context | `Guild` `Message` `TextChannel` `VoiceChannel` `MessageReaction`  | The context to check the nickname in | &nbsp; |
| user&#x3D;client.user | `User`  | The user who's name to check | *Optional* |




##### Returns


- `String`  The nickname of the user in the given context


##### Example
`events/message.js`:
```js
9  |  console.log(message.guild.members.map(i => client.getNickname(message, i.user)));
10 |  console.log(client.getNickname(message));
```
Output:
```js
["MoreThanTom","MoreThanAFairyTailFan","Zomatree","LonelyBoy","Boostio","MoreThanDrew","Temp","Champions bot","Mr Banker","js bot","banky bot","BusyBot"]
"BusyBot"
```


#### client.multiplePrompt(channel, options[, embed, subject]) 

Prompts user to choose string from array with reactions




##### Parameters

| Name | Type | Description |  |
| ---- | ---- | ----------- | -------- |
| channel | `Channel`  | Discord channel to send the prompt to | &nbsp; |
| options | `Array.<String>`  | An array of strings representing the choices for the user | &nbsp; |
| embed | `Embed` `String`  | Used as message to send to channel, will be given reactions up to the number of strings in [options]. Should explain what each option mean | *Optional* |
| subject | `User` `String`  | Only allow this user to respond to the prompt | *Optional* |




##### Returns


- `Promise.<String|Error>`  Resolves to the string the user chose


##### Example
`events/message.js`:
```js
9 |  client.multiplePrompt(message.channel, message.guild.members.map(i => client.getNickname(message, i.user)).slice(0,8), "Pick a number!", message.author).then(s => client.successEmbed(message.channel, s));
```

![image](https://user-images.githubusercontent.com/25057690/45647165-1349f780-babd-11e8-9d71-d0f9634c6dae.png)
![image](https://user-images.githubusercontent.com/25057690/45647242-4d1afe00-babd-11e8-973b-d4a0fbd0ca89.png)

##### Example 2
`events/message.js`:
```js
9 |  client.multiplePrompt(message.channel, ["Hey", "What's", "Your", "Favourite", "Number?"]).then(console.log);
```
![image](https://user-images.githubusercontent.com/25057690/45647425-bd298400-babd-11e8-9700-e57f9e49534d.png)
```js
"What's"
```


**Semantic versioning classification:**  
- [x] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
